### PR TITLE
Move InternalsVisibleTo to AssemblyInfo

### DIFF
--- a/KNXLib/DPT/DataPointTranslator.cs
+++ b/KNXLib/DPT/DataPointTranslator.cs
@@ -1,7 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("KNXLibTests")]
 
 namespace KNXLib.DPT
 {

--- a/KNXLib/Properties/AssemblyInfo.cs
+++ b/KNXLib/Properties/AssemblyInfo.cs
@@ -34,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: InternalsVisibleTo("KNXLibTests")]


### PR DESCRIPTION
InternalsVisibleTo is usually located in AssemblyInfo.