### PR TITLE
ReceiveTimeout too short in production system

### DIFF
--- a/src/KNXLib/KnxConnectionTunneling.cs
+++ b/src/KNXLib/KnxConnectionTunneling.cs
@@ -86,7 +86,7 @@ namespace KNXLib
 
                 _udpClient = new UdpClient(_localEndpoint)
                 {
-                    Client = { DontFragment = true, SendBufferSize = 0, ReceiveTimeout = stateRequestTimerInterval + 1000 }
+                    Client = { DontFragment = true, SendBufferSize = 0, ReceiveTimeout = stateRequestTimerInterval * 2 }
                 };
             }
             catch (SocketException ex)


### PR DESCRIPTION
ReceiveTimeout = stateRequestTimerInterval * 2 is safe for most cases