### PR TITLE
Added a note about ActionMessageCode to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,10 @@ If connecting in routing mode:
 
 If connecting in tunneling mode:
 * make sure the system firewall allows incoming connections to the specified `localPort`
+
+If sending actions is not working for you, you might need to define the parameter `ActionMessageCode` on the connection. Some KNX Router/Interfaces need this to be set to 0x29 for example.
+
+```csharp
+connection = new KnxConnectionRouting();
+connection.ActionMessageCode = 0x29;
+```

--- a/src/KNXLib/KnxLockManager.cs
+++ b/src/KNXLib/KnxLockManager.cs
@@ -42,7 +42,8 @@ namespace KNXLib
 
         public void PerformLockedOperation(Action action)
         {
-            // TODO: Shouldn't this check if we are connected?
+            if (!_isConnected)
+                throw new InvalidOperationException("Unable to perform action: KNX is not connected.");
 
             try
             {


### PR DESCRIPTION
There's a comment on the `ActionMessageCode` property in code but it's not clear from the README that one might need to set the `ActionMessageCode` to get the lib working properly.